### PR TITLE
Propagate `Base.active_project()` from the "manager" process to the worker processes (but allow the user to override that behavior by specifying `JULIA_PROJECT` in `params[:env]`)

### DIFF
--- a/src/slurmmanager.jl
+++ b/src/slurmmanager.jl
@@ -74,11 +74,35 @@ end
 
 function _new_environment_additions(params_env::Dict{String, String})
   env2 = Dict{String, String}()
+  user_did_specify_JULIA_PROJECT = false
+
   for (name, value) in pairs(params_env)
     # For each key-value mapping in `params[:env]`, we respect that mapping and we pass it
     # to the workers.
     env2[name] = value
+
+    # If the user did specify `JULIA_{PROJECT,LOAD_PATH,DEPOT_PATH}` in `params[:env]`, then
+    # we respect that value, and we pass it to the workers.
+    if name == "JULIA_PROJECT"
+      user_did_specify_JULIA_PROJECT = true
+      @debug "The user did specify a value for JULIA_PROJECT in the `env` kwarg to `addprocs()`; that value will be passed to the workers" env2[JULIA_PROJECT]
+    end
   end
+
+  # If the user did not specify `JULIA_PROJECT` in `params[:env]`, then we pass
+  # JULIA_PROJECT=Base.active_project() to the workers.
+  #
+  # This use case is commonly hit when the user does NOT set the `JULIA_PROJECT` environment
+  # variable but DOES start Julia with either `julia --project` or `julia --project=something`.
+  #
+  # https://github.com/kleinhenz/SlurmClusterManager.jl/issues/16
+  if !user_did_specify_JULIA_PROJECT
+    # Important note: We use  Base.active_project() here.
+    # We do NOT use Base.ACTIVE_PROJECT[], because it is not part of Julia's public API.
+    env2["JULIA_PROJECT"] = Base.active_project()
+    @debug "Passing JULIA_PROJECT=Base.active_project() to the workers" env2["JULIA_PROJECT"]
+  end
+
   return env2
 end
 


### PR DESCRIPTION
Fixes #16.
Replacement for #17 (closes #17).

This PR depends on:
- [ ] #20