### PR TITLE
[BREAKING] Remove the `verbose` field, and use the Julia logging system instead

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SlurmClusterManager"
 uuid = "c82cd089-7bf7-41d7-976b-6b5d413cbe0a"
 authors = ["Joseph Kleinhenz <kleinhenz.joseph@gmail.com>"]
-version = "0.1.5"
+version = "1.0.0"
 
 [deps]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/src/slurmmanager.jl
+++ b/src/slurmmanager.jl
@@ -7,12 +7,11 @@ The environment variables `SLURM_JOB_ID` or `SLURM_JOBID` and `SLURM_NTASKS` mus
 mutable struct SlurmManager <: ClusterManager
   jobid::Int
   ntasks::Int
-  verbose::Bool
   launch_timeout::Float64
   srun_post_exit_sleep::Float64
   srun_proc
 
-  function SlurmManager(;verbose=false, launch_timeout=60.0, srun_post_exit_sleep=0.01)
+  function SlurmManager(; launch_timeout=60.0, srun_post_exit_sleep=0.01)
 
     jobid =
     if "SLURM_JOB_ID" in keys(ENV)
@@ -39,7 +38,7 @@ mutable struct SlurmManager <: ClusterManager
     jobid = parse(Int, jobid)
     ntasks = parse(Int, ntasks)
 
-    new(jobid, ntasks, verbose, launch_timeout, srun_post_exit_sleep, nothing)
+    new(jobid, ntasks, launch_timeout, srun_post_exit_sleep, nothing)
   end
 end
 
@@ -201,7 +200,7 @@ function Distributed.launch(manager::SlurmManager, params::Dict, instances_arr::
         write(manager.srun_proc, "\n")
 
         t = @async for i in 1:manager.ntasks
-          manager.verbose && println("connecting to worker $i out of $(manager.ntasks)")
+          @debug "connecting to worker $i out of $(manager.ntasks)"
 
           line = readline(manager.srun_proc)
           m = match(r".*:(\d*)#(.*)", line)


### PR DESCRIPTION
Important note: This is a breaking change, and thus will require a breaking release of SlurmClusterManager.jl.

The idea here is to get rid of the `.verbose` field, and instead log the message using `@debug`. Then, if the user wants to turn on verbose logging, they just e.g. set the `JULIA_DEBUG=SlurmClusterManager` environment variable.

This allows the logging in this package to be composable with the rest of the `Logging` ecosystem in Julia.