### PR TITLE
CI: Multiple tweaks to the CI workflow file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 100
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,13 @@ on:
       - master
       - develop
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -21,14 +25,19 @@ jobs:
           - '1.10.7' # current LTS
           - '1.11.2' # currently the latest stable release
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
       - name: Setup Docker
         run: |
           docker version
           docker compose version
-          docker build --build-arg JULIA_VERSION=${{matrix.version}} -t slurm-cluster-julia -f ci/Dockerfile .
+          docker build --build-arg JULIA_VERSION="${MATRIX_VERSION:?}" -t slurm-cluster-julia -f ci/Dockerfile .
           docker compose -f ci/docker-compose.yml up -d
           docker ps
+        env:
+          MATRIX_VERSION: ${{matrix.version}}
       - name: Test Docker
         run: |
           docker exec -t slurmctld julia --version


### PR DESCRIPTION
1. Update `actions/checkout` from `v2` to `v4`.
2. Use Dependabot to keep GitHub Actions up-to-date.
3. Add a timeout to the `test` job.
4. Set `contents: read` for the GITHUB_TOKEN (because we don't need any write permissions).
5. Set `persist-credentials: false` in `actions/checkout`.
6. Pass the matrix value through an intermediate environment variable.
7. Disable fast-failing.