### PR TITLE
CI: In the Dockerfile, pin the full `sha256` digest in the `FROM` line

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM jkleinh/slurm-cluster as base
+FROM jkleinh/slurm-cluster@sha256:afd20dafc831b0fa781460dc871232579ccf1b54955e434531394c331ce388e4 as base
 MAINTAINER Joseph Kleinhenz <jkleinh@umich.edu>
 
 ARG JULIA_VERSION=1.6.0


### PR DESCRIPTION
The idea here is that if a new build of the Docker image is pushed to Docker Hub, we ensure that the CI in this repo won't randomly start breaking (because we pin the exact `sha256` digest that we want to use).