### PR TITLE
Put the entire test suite inside a top-level `@testset`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,41 +2,44 @@
 
 using Distributed, Test, SlurmClusterManager
 
-# test that slurm is available
-@test !(Sys.which("sinfo") === nothing)
-
-# submit job
-# project should point to top level dir so that SlurmClusterManager is available to script.jl
-project_path = abspath(joinpath(@__DIR__, ".."))
-println("project_path = $project_path")
-jobid = withenv("JULIA_PROJECT"=>project_path) do
-  strip(read(`sbatch --export=ALL --parsable -n 4 -o test.out script.jl`, String))
-end
-println("jobid = $jobid")
-
-# get job state from jobid
-getjobstate = jobid -> begin
-  cmd = Cmd(`scontrol show jobid=$jobid`, ignorestatus=true)
-  info = read(cmd, String)
-  state = match(r"JobState=(\S*)", info)
-  return state === nothing ? nothing : state.captures[1]
-end
-
-# wait for job to complete
-status = timedwait(60.0, pollint=1.0) do
+@testset "SlurmClusterManager.jl" begin
+  # test that slurm is available
+  @test !(Sys.which("sinfo") === nothing)
+  
+  # submit job
+  # project should point to top level dir so that SlurmClusterManager is available to script.jl
+  project_path = abspath(joinpath(@__DIR__, ".."))
+  println("project_path = $project_path")
+  jobid = withenv("JULIA_PROJECT"=>project_path) do
+    strip(read(`sbatch --export=ALL --parsable -n 4 -o test.out script.jl`, String))
+  end
+  println("jobid = $jobid")
+  
+  # get job state from jobid
+  getjobstate = jobid -> begin
+    cmd = Cmd(`scontrol show jobid=$jobid`, ignorestatus=true)
+    info = read(cmd, String)
+    state = match(r"JobState=(\S*)", info)
+    return state === nothing ? nothing : state.captures[1]
+  end
+  
+  # wait for job to complete
+  status = timedwait(60.0, pollint=1.0) do
+    state = getjobstate(jobid)
+    state == nothing && return false
+    println("jobstate = $state")
+    return state == "COMPLETED" || state == "FAILED"
+  end
+  
   state = getjobstate(jobid)
-  state == nothing && return false
-  println("jobstate = $state")
-  return state == "COMPLETED" || state == "FAILED"
-end
+  
+  # check that job finished running within timelimit (either completed or failed)
+  @test status == :ok
+  @test state == "COMPLETED"
+  
+  # print job output
+  output = read("test.out", String)
+  println("script output:")
+  println(output)
 
-state = getjobstate(jobid)
-
-# check that job finished running within timelimit (either completed or failed)
-@test status == :ok
-@test state == "COMPLETED"
-
-# print job output
-output = read("test.out", String)
-println("script output:")
-println(output)
+end # testset "SlurmClusterManager.jl"


### PR DESCRIPTION
This PR makes three changes:
1. Create a top-level `@testset`.
2. Put the entire test suite inside the top-level `@testset`.
3. Indent all of the code inside the `@testset`.

When reviewing this PR, I recommend checking the "Hide whitespace" checkbox in the GitHub PR diff view. Otherwise, all the lines from change 3 above will clutter the diff, despite the fact that the only change on those lines is whitespace (indentation).

## Motivation

Before this PR: if a single `@test` fails, no subsequent tests will be run.

After this PR: if a single `@test` fails, the subsequent tests will still be run.