### PR TITLE
More test suite tweaks

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,13 @@ import Test
 # Bring some names into scope, just for convenience:
 using Test: @testset, @test
 
+const original_JULIA_DEBUG = strip(get(ENV, "JULIA_DEBUG", ""))
+if isempty(original_JULIA_DEBUG)
+  ENV["JULIA_DEBUG"] = "SlurmClusterManager"
+else
+  ENV["JULIA_DEBUG"] = original_JULIA_DEBUG * ",SlurmClusterManager"
+end
+
 # test that slurm is available
 @test !(Sys.which("sinfo") === nothing)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,12 @@
-#!/usr/bin/env julia
+# We don't use `using Foo` here.
+# We either use `using Foo: hello, world`, or we use `import Foo`.
+# https://github.com/JuliaLang/julia/pull/42080
+import SlurmClusterManager
+import Distributed
+import Test
 
-using Distributed, Test, SlurmClusterManager
+# Bring some names into scope, just for convenience:
+using Test: @testset, @test
 
 # test that slurm is available
 @test !(Sys.which("sinfo") === nothing)

--- a/test/script.jl
+++ b/test/script.jl
@@ -20,7 +20,7 @@ const hosts = map(workers()) do id
   remotecall_fetch(() -> gethostname(), id)
 end
 sort!(hosts)
-println(hosts)
+println("List of hosts: ", hosts)
 
 # We don't use `@assert` here, for reason described above.
 if hosts != ["c1", "c1", "c2", "c2"]


### PR DESCRIPTION
1. Test suite: Make a `println()` statement slightly more meaningful.
2. Test suite: Use `using Foo: bar, baz` or `import Foo` (but never bare `using Foo`).
3. Test suite: append to `JULIA_DEBUG`.