### PR TITLE
Test suite: propagate `JULIA_PROJECT=Base.active_project()`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,3 @@
-const directory_separator = Sys.iswindows() ? ';' : ':'
-@info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator) Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
-@info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
-
-println(Base.stderr, "# BEGIN contents of project.toml: $(Base.active_project())")
-read(Base.active_project(), String) |> println
-println(Base.stderr, "# END contents of project.toml: $(Base.active_project())")
-
-Base.flush(Base.stdout)
-Base.flush(Base.stderr)
-
 # We don't use `using Foo` here.
 # We either use `using Foo: hello, world`, or we use `import Foo`.
 # https://github.com/JuliaLang/julia/pull/42080
@@ -84,3 +73,6 @@ end
   println(output)
 
 end # testset "SlurmClusterManager.jl"
+
+Base.flush(Base.stdout)
+Base.flush(Base.stderr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,7 +41,7 @@ end
   @test !(Sys.which("sinfo") === nothing)
 
   env_vars = generate_julia_env_vars
-  JULIA_PROJECT) = env_vars.JULIA_PROJECT
+  JULIA_PROJECT = env_vars.JULIA_PROJECT
   JULIA_LOAD_PATH = env_vars.JULIA_LOAD_PATH
   @info "" JULIA_PROJECT JULIA_LOAD_PATH
   

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,9 @@ const directory_separator = Sys.iswindows() ? ';' : ':'
 @info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator) Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
 @info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
 
-println(Base.stderr, "# BEGIN contents of project.toml")
-read(Base.active_project() , String) |> println
-println(Base.stderr, "# END contents of project.toml")
+println(Base.stderr, "# BEGIN contents of project.toml: $(Base.active_project())")
+read(Base.active_project(), String) |> println
+println(Base.stderr, "# END contents of project.toml: $(Base.active_project())")
 
 Base.flush(Base.stdout)
 Base.flush(Base.stderr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,7 +21,11 @@ end
   
   # submit job
   # project should point to top level dir so that SlurmClusterManager is available to script.jl
-  project_path = abspath(joinpath(@__DIR__, ".."))
+  #
+  # Use `sbatch` to submit the Slurm job.
+  # Make sure to propagate `JULIA_PROJECT=Base.active_project()`.
+  # This ensures that SlurmClusterManager.jl, Distributed.jl, and Test.jl are available.
+  project_path = Base.active_project()
   println("project_path = $project_path")
   jobid = withenv("JULIA_PROJECT"=>project_path) do
     strip(read(`sbatch --export=ALL --parsable -n 4 -o test.out script.jl`, String))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,12 +31,13 @@ end
   # project_path = Base.active_project()
 
   directory_separator = Sys.iswindows() ? ';' : ':'
-  SlurmClusterManagerROOTDIR_testdir = @__DIR__                                                 # ./SlurmClusterManager.jl/test
-  SlurmClusterManagerROOTDIR = dirname(SlurmClusterManagerROOTDIR_testdir)                      # ./SlurmClusterManager.jl
-  SlurmClusterManagerROOTDIR_projecttoml = joinpath(SlurmClusterManagerROOTDIR, "Project.toml") # ./SlurmClusterManager.jl/Project.toml
+  SlurmClusterManagerROOTDIR_testdir = @__DIR__                                                 # SlurmClusterManager.jl/test
+  SlurmClusterManagerROOTDIR = dirname(SlurmClusterManagerROOTDIR_testdir)                      # SlurmClusterManager.jl
+  SlurmClusterManagerROOTDIR_projecttoml = joinpath(SlurmClusterManagerROOTDIR, "Project.toml") # SlurmClusterManager.jl/Project.toml
   
-  JULIA_PROJECT = abspath(SlurmClusterManagerROOTDIR_projecttoml)                               # ./SlurmClusterManager.jl/Project.toml
-  JULIA_LOAD_PATH = abspath(SlurmClusterManagerROOTDIR_testdir)                                 # ./SlurmClusterManager.jl/test
+  JULIA_PROJECT = SlurmClusterManagerROOTDIR_projecttoml                                        # SlurmClusterManager.jl/Project.toml
+  JULIA_LOAD_PATH = "@$(directory_separator)$(SlurmClusterManagerROOTDIR_testdir)"              # @:SlurmClusterManager.jl/test
+  
 
   @info "" JULIA_PROJECT JULIA_LOAD_PATH
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,6 @@
+@info "" Base.active_project() Base.DEPOT_PATH Base.LOAD_PATH
+@info "" get(ENV, "JULIA_PROJECT", "") get(ENV, "JULIA_DEPOT_PATH", "") get(ENV, "JULIA_LOAD_PATH", "")
+
 # We don't use `using Foo` here.
 # We either use `using Foo: hello, world`, or we use `import Foo`.
 # https://github.com/JuliaLang/julia/pull/42080

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,13 @@ const directory_separator = Sys.iswindows() ? ';' : ':'
 @info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator) Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
 @info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
 
+println(Base.stderr, "# BEGIN contents of project.toml")
+read(Base.active_project() , String) |> println
+println(Base.stderr, "# END contents of project.toml")
+
+Base.flush(Base.stdout)
+Base.flush(Base.stderr)
+
 # We don't use `using Foo` here.
 # We either use `using Foo: hello, world`, or we use `import Foo`.
 # https://github.com/JuliaLang/julia/pull/42080

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
-@info "" Base.active_project() Base.DEPOT_PATH Base.LOAD_PATH
-@info "" get(ENV, "JULIA_PROJECT", "") get(ENV, "JULIA_DEPOT_PATH", "") get(ENV, "JULIA_LOAD_PATH", "")
+const directory_separator = Sys.iswindows() ? ';' : ':'
+@info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
+@info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
 
 # We don't use `using Foo` here.
 # We either use `using Foo: hello, world`, or we use `import Foo`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 const directory_separator = Sys.iswindows() ? ';' : ':'
-@info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
+@info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator) Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
 @info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
 
 # We don't use `using Foo` here.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,7 @@ import Test
 # Bring some names into scope, just for convenience:
 using Test: @testset, @test
 
-function generate_JULIA_PROJECT_and_JULIA_LOAD_PATH()
+function generate_julia_env_vars()
   # Make sure to propagate `JULIA_PROJECT=SlurmClusterManager/Project.toml`.
   # This ensures that SlurmClusterManager.jl and Distributed.jl are available.
   #
@@ -24,7 +24,9 @@ function generate_JULIA_PROJECT_and_JULIA_LOAD_PATH()
   JULIA_PROJECT = SlurmClusterManagerROOTDIR_projecttoml                                        # SlurmClusterManager.jl/Project.toml
   JULIA_LOAD_PATH = "@$(directory_separator)$(SlurmClusterManagerROOTDIR_testdir)"              # @:SlurmClusterManager.jl/test
 
-  return (; JULIA_PROJECT, JULIA_LOAD_PATH)
+  env_vars = (; JULIA_PROJECT, JULIA_LOAD_PATH)
+
+  return env_vars
 end
 
 const original_JULIA_DEBUG = strip(get(ENV, "JULIA_DEBUG", ""))
@@ -37,12 +39,10 @@ end
 @testset "SlurmClusterManager.jl" begin
   # test that slurm is available
   @test !(Sys.which("sinfo") === nothing)
-  
-  # submit job
-  # project should point to top level dir so that SlurmClusterManager is available to script.jl
-  #
-  # 
-  (; JULIA_PROJECT, JULIA_LOAD_PATH) = generate_JULIA_PROJECT_and_JULIA_LOAD_PATH()
+
+  env_vars = generate_julia_env_vars
+  JULIA_PROJECT) = env_vars.JULIA_PROJECT
+  JULIA_LOAD_PATH = env_vars.JULIA_LOAD_PATH
   @info "" JULIA_PROJECT JULIA_LOAD_PATH
   
   # Use `sbatch` to submit the Slurm job.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,6 +73,3 @@ end
   println(output)
 
 end # testset "SlurmClusterManager.jl"
-
-Base.flush(Base.stdout)
-Base.flush(Base.stderr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -31,12 +31,12 @@ end
   # project_path = Base.active_project()
 
   directory_separator = Sys.iswindows() ? ';' : ':'
-  SlurmClusterManagerROOTDIR_testdir = @__DIR__                              # ./SlurmClusterManager.jl/test
-  SlurmClusterManagerROOTDIR = dirname(rootdir_testdir)                      # ./SlurmClusterManager.jl
-  SlurmClusterManagerROOTDIR_projecttoml = joinpath(rootdir, "Project.toml") # ./SlurmClusterManager.jl/Project.toml
+  SlurmClusterManagerROOTDIR_testdir = @__DIR__                                                 # ./SlurmClusterManager.jl/test
+  SlurmClusterManagerROOTDIR = dirname(SlurmClusterManagerROOTDIR_testdir)                      # ./SlurmClusterManager.jl
+  SlurmClusterManagerROOTDIR_projecttoml = joinpath(SlurmClusterManagerROOTDIR, "Project.toml") # ./SlurmClusterManager.jl/Project.toml
   
-  JULIA_PROJECT = abspath(SlurmClusterManagerROOTDIR_projecttoml)            # ./SlurmClusterManager.jl/Project.toml
-  JULIA_LOAD_PATH = abspath(SlurmClusterManagerROOTDIR_testdir)              # ./SlurmClusterManager.jl/test
+  JULIA_PROJECT = abspath(SlurmClusterManagerROOTDIR_projecttoml)                               # ./SlurmClusterManager.jl/Project.toml
+  JULIA_LOAD_PATH = abspath(SlurmClusterManagerROOTDIR_testdir)                                 # ./SlurmClusterManager.jl/test
 
   @info "" JULIA_PROJECT JULIA_LOAD_PATH
 

--- a/test/script.jl
+++ b/test/script.jl
@@ -4,9 +4,9 @@ const directory_separator = Sys.iswindows() ? ';' : ':'
 @info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator) Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
 @info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
 
-println(Base.stderr, "# BEGIN contents of project.toml")
-read(Base.active_project() , String) |> println
-println(Base.stderr, "# END contents of project.toml")
+println(Base.stderr, "# BEGIN contents of project.toml: $(Base.active_project())")
+read(Base.active_project(), String) |> println
+println(Base.stderr, "# END contents of project.toml: $(Base.active_project())")
 
 my_pkg = only([x for x in Base.loaded_modules if x[1].name == "Pkg"])[2]
 my_pkg.status()

--- a/test/script.jl
+++ b/test/script.jl
@@ -1,6 +1,5 @@
 #!/usr/bin/env julia
 
-# TODO: Delete the following line:
 import Test
 
 # We don't use `using Foo` here.

--- a/test/script.jl
+++ b/test/script.jl
@@ -1,6 +1,7 @@
 #!/usr/bin/env julia
 
-@show Base.active_project()
+@info "" Base.active_project() Base.DEPOT_PATH Base.LOAD_PATH
+@info "" get(ENV, "JULIA_PROJECT", "") get(ENV, "JULIA_DEPOT_PATH", "") get(ENV, "JULIA_LOAD_PATH", "")
 
 # We don't use `using Foo` here.
 # We either use `using Foo: hello, world`, or we use `import Foo`.

--- a/test/script.jl
+++ b/test/script.jl
@@ -4,6 +4,9 @@ const directory_separator = Sys.iswindows() ? ';' : ':'
 @info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator) Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
 @info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
 
+my_pkg = only([x for x in Base.loaded_modules if x[1].name == "Pkg"])[2]
+my_pkg.status()
+
 # We don't use `using Foo` here.
 # We either use `using Foo: hello, world`, or we use `import Foo`.
 # https://github.com/JuliaLang/julia/pull/42080

--- a/test/script.jl
+++ b/test/script.jl
@@ -1,7 +1,7 @@
 #!/usr/bin/env julia
 
 const directory_separator = Sys.iswindows() ? ';' : ':'
-@info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
+@info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator) Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
 @info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
 
 # We don't use `using Foo` here.

--- a/test/script.jl
+++ b/test/script.jl
@@ -1,15 +1,7 @@
 #!/usr/bin/env julia
 
-const directory_separator = Sys.iswindows() ? ';' : ':'
-@info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator) Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
-@info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
-
-println(Base.stderr, "# BEGIN contents of project.toml: $(Base.active_project())")
-read(Base.active_project(), String) |> println
-println(Base.stderr, "# END contents of project.toml: $(Base.active_project())")
-
-my_pkg = only([x for x in Base.loaded_modules if x[1].name == "Pkg"])[2]
-my_pkg.status()
+# TODO: Delete the following line:
+import Test
 
 # We don't use `using Foo` here.
 # We either use `using Foo: hello, world`, or we use `import Foo`.

--- a/test/script.jl
+++ b/test/script.jl
@@ -1,7 +1,8 @@
 #!/usr/bin/env julia
 
-@info "" Base.active_project() Base.DEPOT_PATH Base.LOAD_PATH
-@info "" get(ENV, "JULIA_PROJECT", "") get(ENV, "JULIA_DEPOT_PATH", "") get(ENV, "JULIA_LOAD_PATH", "")
+const directory_separator = Sys.iswindows() ? ';' : ':'
+@info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
+@info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
 
 # We don't use `using Foo` here.
 # We either use `using Foo: hello, world`, or we use `import Foo`.

--- a/test/script.jl
+++ b/test/script.jl
@@ -1,5 +1,7 @@
 #!/usr/bin/env julia
 
+@show Base.active_project()
+
 # We don't use `using Foo` here.
 # We either use `using Foo: hello, world`, or we use `import Foo`.
 # https://github.com/JuliaLang/julia/pull/42080

--- a/test/script.jl
+++ b/test/script.jl
@@ -4,6 +4,10 @@ const directory_separator = Sys.iswindows() ? ';' : ':'
 @info "" Base.active_project() Base.DEPOT_PATH=join(Base.DEPOT_PATH, directory_separator) Base.LOAD_PATH=join(LOAD_PATH, directory_separator)
 @info "" JULIA_PROJECT=get(ENV, "JULIA_PROJECT", "") JULIA_DEPOT_PATH=get(ENV, "JULIA_DEPOT_PATH", "") JULIA_LOAD_PATH=get(ENV, "JULIA_LOAD_PATH", "")
 
+println(Base.stderr, "# BEGIN contents of project.toml")
+read(Base.active_project() , String) |> println
+println(Base.stderr, "# END contents of project.toml")
+
 my_pkg = only([x for x in Base.loaded_modules if x[1].name == "Pkg"])[2]
 my_pkg.status()
 


### PR DESCRIPTION
I want to be able to use the `Test` stdlib in the `test/script.jl` script. So we need to propagate `JULIA_PROJECT=Base.active_project()` in order to make sure that `Test` is available.